### PR TITLE
PLAT-3297 validate alerting_slack within job meta info

### DIFF
--- a/nomad-deploy-file-validation/validate.py
+++ b/nomad-deploy-file-validation/validate.py
@@ -90,6 +90,7 @@ def validate_hcl(hcl_cfg):
     json_config = hcl.load(io.StringIO(hcl_cfg))
     assert isinstance(json_config, dict), "not valid json configuration format, root value must be an object"
     assert 'job' in json_config, "configuration has not 'Job' definition inside a root object"
+    assert json_config['job']['1']['meta']['alerting_slack'] in ['platform-alerts','frontend-alerts','policy-alerts','claim-support'] , "Job meta 'alerting_slack' has to be configured with one of 'platform-alerts','frontend-alerts','policy-alerts','claim-support'"
 
 
 def validate_yaml(file):


### PR DESCRIPTION
I know it is not nice to maintain channel-names within this code but when we assert only on *anything* we have the problem that the slack webhook api can only send to ONE predefined channel which means we have to prepare the webhook apis for each channel in advance.
Or at least I could not find out how to send a message to any channel.