### PR TITLE
[PLAT-5569] Add SRSO exception to kernel-notify

### DIFF
--- a/kernel-notification.sh
+++ b/kernel-notification.sh
@@ -39,7 +39,7 @@ if [ -f "$cursor_file" ]; then
 fi
 
 set +e
-log="$(journalctl $args)"
+log="$(journalctl $args | grep -v 'Speculative Return Stack Overflow')"
 rv=$?
 set -e
 


### PR DESCRIPTION
https://sisu-agile.atlassian.net/browse/PLAT-5569

Adding an Exception to `kernel-notification.sh` to ignore the SRSO issue.

The issue is already mitigated by the Kenrnel:
`Mitigation: safe RET, no microcode`